### PR TITLE
Document DXVK archive fix in release notes

### DIFF
--- a/Release Notes/PatchOpsIII v1.0.4.md
+++ b/Release Notes/PatchOpsIII v1.0.4.md
@@ -28,6 +28,7 @@ The latest release of **PatchOpsIII** is here! Version **1.0.4** brings signific
 
 ## 🛠 **Fixes:**
 - Addressed various minor bugs and stability issues.
+- Fixed DXVK-GPLAsync auto-installation failures caused by new upstream archive formats by preferring extractable assets and supporting `.tar.zst` packages out of the box.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PySide6
 requests
 vdf
+zstandard


### PR DESCRIPTION
## Summary
- add a 1.0.4 release note entry that calls out the DXVK-GPLAsync archive compatibility fix
- clean up `requirements.txt` so the optional zstandard dependency is listed on its own line

## Testing
- python -m compileall dxvk_manager.py

------
https://chatgpt.com/codex/tasks/task_e_690102bdca78832989968f0b74875591