### PR TITLE
Auto-Update Function

### DIFF
--- a/version.py
+++ b/version.py
@@ -3,10 +3,4 @@ from __future__ import annotations
 
 import os
 
-APP_VERSION: str = os.environ.get("PATCHOPSIII_VERSION", "0.0.0")
-"""Current application version string.
-
-The value defaults to ``"0.0.0"`` when running from source, but release builds
-should inject the real version using the ``PATCHOPSIII_VERSION`` environment
-variable during packaging.
-"""
+APP_VERSION: str = os.environ.get("PATCHOPSIII_VERSION", "1.1.0")


### PR DESCRIPTION
## Summary
- extend the updater utilities to select Linux AppImage releases and prompt users through Gear Lever
- hook the main window into the Linux update flow so AppImage builds can launch Gear Lever or surface installation guidance
- keep Windows update handling intact while sharing common release metadata helpers

## Testing
- python -m compileall main.py updater.py version.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691787903d108329bd8375b4c001758e)