### PR TITLE
Mitigate Bitdefender false positives on Windows

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -423,6 +423,10 @@ jobs:
             if [ -d "$dir" ]; then
               for archive in "${dir}"/*.zip "${dir}"/*.tar "${dir}"/*.tar.gz "${dir}"/*.tgz; do
                 [ -e "$archive" ] || continue
+                if [ "$dir" = "artifacts/windows" ] && [ "$(basename "$archive")" = "PatchOpsIII-windows.zip" ]; then
+                  echo "Keeping Windows standalone archive intact: $archive"
+                  continue
+                fi
                 echo "Extracting $archive"
                 case "$archive" in
                   *.tar.gz|*.tgz) tar -xzf "$archive" -C "$dir" ;;
@@ -469,7 +473,7 @@ jobs:
           linux_vt = os.environ.get("LINUX_VT_URL", "").strip() or "https://www.virustotal.com/"
           windows_hash = os.environ.get("WINDOWS_HASH", "").strip() or "None"
           linux_hash = os.environ.get("LINUX_HASH", "").strip() or "None"
-          asset_windows = "PatchOpsIII-Beta.exe"
+          asset_windows = "PatchOpsIII-Beta-windows.zip"
           asset_linux = "PatchOpsIII-Beta.AppImage"
           base_url = f"https://github.com/{repo}/releases/download/{tag}"
           windows_download = f"{base_url}/{asset_windows}"
@@ -512,15 +516,15 @@ jobs:
           set -euo pipefail
           mkdir -p release
           echo "Collecting release binaries"
-          win_exec=$(find artifacts/windows -type f -name 'PatchOpsIII.exe' -print -quit)
-          if [ -z "$win_exec" ]; then
-            echo "Windows executable not found under artifacts/windows" >&2
+          win_archive=$(find artifacts/windows -type f -name 'PatchOpsIII-windows.zip' -print -quit)
+          if [ -z "$win_archive" ]; then
+            echo "Windows archive not found under artifacts/windows" >&2
             find artifacts/windows -type f -print >&2
             exit 1
           fi
-          cp "$win_exec" "release/PatchOpsIII-Beta.exe"
-          if [ -f "$(dirname "$win_exec")/PatchOpsIII.sig" ]; then
-            cp "$(dirname "$win_exec")/PatchOpsIII.sig" "release/PatchOpsIII-Beta.sig"
+          cp "$win_archive" "release/PatchOpsIII-Beta-windows.zip"
+          if [ -f "$(dirname "$win_archive")/PatchOpsIII.sig" ]; then
+            cp "$(dirname "$win_archive")/PatchOpsIII.sig" "release/PatchOpsIII-Beta.sig"
           fi
           linux_exec=$(find artifacts/linux -type f -name 'PatchOpsIII.AppImage' -print -quit)
           if [ -z "$linux_exec" ]; then

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -417,6 +417,10 @@ jobs:
             if [ -d "$dir" ]; then
               for archive in "${dir}"/*.zip "${dir}"/*.tar "${dir}"/*.tar.gz "${dir}"/*.tgz; do
                 [ -e "$archive" ] || continue
+                if [ "$dir" = "artifacts/windows" ] && [ "$(basename "$archive")" = "PatchOpsIII-windows.zip" ]; then
+                  echo "Keeping Windows standalone archive intact: $archive"
+                  continue
+                fi
                 echo "Extracting $archive"
                 case "$archive" in
                   *.tar.gz|*.tgz) tar -xzf "$archive" -C "$dir" ;;
@@ -463,7 +467,7 @@ jobs:
           linux_vt = os.environ.get("LINUX_VT_URL", "").strip() or "https://www.virustotal.com/"
           windows_hash = os.environ.get("WINDOWS_HASH", "").strip() or "None"
           linux_hash = os.environ.get("LINUX_HASH", "").strip() or "None"
-          asset_windows = "PatchOpsIII.exe"
+          asset_windows = "PatchOpsIII-windows.zip"
           asset_linux = "PatchOpsIII.AppImage"
           base_url = f"https://github.com/{repo}/releases/download/{tag}"
           windows_download = f"{base_url}/{asset_windows}"
@@ -506,15 +510,15 @@ jobs:
           set -euo pipefail
           mkdir -p release
           echo "Collecting release binaries"
-          win_exec=$(find artifacts/windows -type f -name 'PatchOpsIII.exe' -print -quit)
-          if [ -z "$win_exec" ]; then
-            echo "Windows executable not found under artifacts/windows" >&2
+          win_archive=$(find artifacts/windows -type f -name 'PatchOpsIII-windows.zip' -print -quit)
+          if [ -z "$win_archive" ]; then
+            echo "Windows archive not found under artifacts/windows" >&2
             find artifacts/windows -type f -print >&2
             exit 1
           fi
-          cp "$win_exec" "release/PatchOpsIII.exe"
-          if [ -f "$(dirname "$win_exec")/PatchOpsIII.sig" ]; then
-            cp "$(dirname "$win_exec")/PatchOpsIII.sig" "release/PatchOpsIII.sig"
+          cp "$win_archive" "release/PatchOpsIII-windows.zip"
+          if [ -f "$(dirname "$win_archive")/PatchOpsIII.sig" ]; then
+            cp "$(dirname "$win_archive")/PatchOpsIII.sig" "release/PatchOpsIII.sig"
           fi
           linux_exec=$(find artifacts/linux -type f -name 'PatchOpsIII.AppImage' -print -quit)
           if [ -z "$linux_exec" ]; then

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -46,7 +46,6 @@ jobs:
         working-directory: .
     env:
       WINDOWS_DIST_DIR: dist\windows
-      WINDOWS_DIST_FOLDER: PatchOpsIII.dist
       WINDOWS_BINARY: PatchOpsIII.exe
       WINDOWS_ARCHIVE: PatchOpsIII-windows.zip
       VT_CLI_ARCHIVE: vt-cli-latest.zip
@@ -106,9 +105,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            PatchOpsIII.build
-            PatchOpsIII.dist
-            PatchOpsIII.onefile-build
+            main.build
+            main.dist
+            main.onefile-build
             .nuitka-cache
           key: nuitka-${{ runner.os }}-${{ steps.version.outputs.raw }}
       - name: Prepare build directories
@@ -116,9 +115,9 @@ jobs:
           if (Test-Path 'dist') { Remove-Item 'dist' -Recurse -Force }
           if (Test-Path 'build') { Remove-Item 'build' -Recurse -Force }
           if ('${{ steps.cache-nuitka.outputs.cache-hit }}' -ne 'true') {
-            if (Test-Path 'PatchOpsIII.build') { Remove-Item 'PatchOpsIII.build' -Recurse -Force }
-            if (Test-Path 'PatchOpsIII.dist') { Remove-Item 'PatchOpsIII.dist' -Recurse -Force }
-            if (Test-Path 'PatchOpsIII.onefile-build') { Remove-Item 'PatchOpsIII.onefile-build' -Recurse -Force }
+            if (Test-Path 'main.build') { Remove-Item 'main.build' -Recurse -Force }
+            if (Test-Path 'main.dist') { Remove-Item 'main.dist' -Recurse -Force }
+            if (Test-Path 'main.onefile-build') { Remove-Item 'main.onefile-build' -Recurse -Force }
             if (Test-Path '.nuitka-cache') { Remove-Item '.nuitka-cache' -Recurse -Force }
           }
           if (Test-Path 'PatchOpsIII.spec') { Remove-Item 'PatchOpsIII.spec' -Force }
@@ -152,9 +151,27 @@ jobs:
             --output-dir=$env:WINDOWS_DIST_DIR `
             --output-filename=$env:WINDOWS_BINARY `
             main.py
+      - name: Resolve standalone output paths
+        run: |
+          $distFolders = Get-ChildItem -Path $env:WINDOWS_DIST_DIR -Directory -Filter '*.dist'
+          $target = $null
+          $distFolder = $null
+          foreach ($folder in $distFolders) {
+            $candidate = Join-Path $folder.FullName $env:WINDOWS_BINARY
+            if (Test-Path $candidate) {
+              $distFolder = $folder.FullName
+              $target = $candidate
+              break
+            }
+          }
+          if (-not $target) {
+            throw "Could not find $env:WINDOWS_BINARY inside any *.dist folder under $env:WINDOWS_DIST_DIR"
+          }
+          "WINDOWS_DIST_FOLDER=$distFolder" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "WINDOWS_TARGET_EXE=$target" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Ensure executable exists
         run: |
-          $target = Join-Path (Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_DIST_FOLDER) $env:WINDOWS_BINARY
+          $target = $env:WINDOWS_TARGET_EXE
           if (-not (Test-Path $target)) {
             throw "$target was not produced"
           }
@@ -166,7 +183,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |
-          $target = Join-Path (Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_DIST_FOLDER) $env:WINDOWS_BINARY
+          $target = $env:WINDOWS_TARGET_EXE
           if (-not (Test-Path $target)) {
             throw "$target was not produced"
           }
@@ -176,7 +193,7 @@ jobs:
           Remove-Item cosign.key
       - name: Package standalone build
         run: |
-          $distFolder = Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_DIST_FOLDER
+          $distFolder = $env:WINDOWS_DIST_FOLDER
           if (-not (Test-Path $distFolder)) {
             throw "$distFolder was not produced"
           }

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -46,7 +46,9 @@ jobs:
         working-directory: .
     env:
       WINDOWS_DIST_DIR: dist\windows
+      WINDOWS_DIST_FOLDER: PatchOpsIII.dist
       WINDOWS_BINARY: PatchOpsIII.exe
+      WINDOWS_ARCHIVE: PatchOpsIII-windows.zip
       VT_CLI_ARCHIVE: vt-cli-latest.zip
       COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
       COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
@@ -124,8 +126,7 @@ jobs:
       - name: Build executable with Nuitka
         run: |
           python -m nuitka `
-            --onefile `
-            --onefile-no-compression `
+            --standalone `
             --windows-disable-console `
             --clang `
             --lto=yes `
@@ -153,7 +154,7 @@ jobs:
             main.py
       - name: Ensure executable exists
         run: |
-          $target = Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_BINARY
+          $target = Join-Path (Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_DIST_FOLDER) $env:WINDOWS_BINARY
           if (-not (Test-Path $target)) {
             throw "$target was not produced"
           }
@@ -165,7 +166,7 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: "1"
         run: |
-          $target = Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_BINARY
+          $target = Join-Path (Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_DIST_FOLDER) $env:WINDOWS_BINARY
           if (-not (Test-Path $target)) {
             throw "$target was not produced"
           }
@@ -173,10 +174,21 @@ jobs:
           $signature = Join-Path $env:WINDOWS_DIST_DIR 'PatchOpsIII.sig'
           cosign sign-blob --yes --key cosign.key --output-signature $signature $target
           Remove-Item cosign.key
+      - name: Package standalone build
+        run: |
+          $distFolder = Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_DIST_FOLDER
+          if (-not (Test-Path $distFolder)) {
+            throw "$distFolder was not produced"
+          }
+          $archive = Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_ARCHIVE
+          if (Test-Path $archive) {
+            Remove-Item $archive -Force
+          }
+          Compress-Archive -Path "$distFolder\\*" -DestinationPath $archive
       - name: Compute Windows hash
         id: compute_hash
         run: |
-          $target = Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_BINARY
+          $target = Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_ARCHIVE
           if (-not (Test-Path $target)) {
             throw "$target was not produced"
           }
@@ -230,14 +242,14 @@ jobs:
         env:
           VT_API_KEY: ${{ env.VT_API_KEY }}
         run: |
-          $target = Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_BINARY
+          $target = Join-Path $env:WINDOWS_DIST_DIR $env:WINDOWS_ARCHIVE
           .\vt.exe scan file $target --apikey $env:VT_API_KEY
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
           name: PatchOpsIII-windows
           path: |
-            ${{ env.WINDOWS_DIST_DIR }}/${{ env.WINDOWS_BINARY }}
+            ${{ env.WINDOWS_DIST_DIR }}/${{ env.WINDOWS_ARCHIVE }}
             ${{ env.WINDOWS_DIST_DIR }}/hash.log
             ${{ env.WINDOWS_DIST_DIR }}/PatchOpsIII.sig
           if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ PatchOpsIII streamlines the setup and upkeep of Black Ops III by surfacing popul
 3. **Run:** Launch `PatchOpsIII.exe` on Windows (or the corresponding binary for other platforms as they become available).
 4. **Dependencies:** The packaged build bundles all required Python dependencies; no additional setup is needed.
 
+### Windows Antivirus / Bitdefender Notes
+- PatchOpsIII has historically used Nuitka onefile packaging on Windows, which extracts runtime files such as `main.dll` into a temporary `%LOCALAPPDATA%\\Temp\\onefile_*` directory at launch. Some antivirus engines, including Bitdefender, may quarantine those temporary files heuristically before the app opens.
+- The Windows CI build now publishes a **standalone zip** instead of a onefile executable so the bundled DLLs stay in the extracted app folder rather than a random temp directory, which reduces false-positive risk.
+- If Bitdefender still blocks the app:
+  1. Download only from the official GitHub Releases page.
+  2. Extract the zip to a normal user-writable folder such as `C:\\Apps\\PatchOpsIII` instead of running it from Downloads, Temp, or inside the game directory.
+  3. Restore the quarantined file and add an exception for the extracted PatchOpsIII folder in Bitdefender.
+  4. If needed, verify the release hash from the release notes / GitHub asset metadata before restoring the file.
+  5. As a fallback, run the project from source with `python main.py`, which avoids onefile-style extraction behavior entirely.
+
 ### Developer Setup
 ```bash
 # clone the repository

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -95,3 +95,12 @@ Displays logs in a terminal view, providing transparency about what operations s
 - [All-around Enhancement Mod](https://steamcommunity.com/sharedfiles/filedetails/?id=2631943123) (full version) currently crashes before launch, so it is not provided as a PatchOpsIII launch option
 - Launch options stability may vary between users
 - Some features are still under testing
+
+### Antivirus False Positives on Windows
+- If Bitdefender or another antivirus quarantines `main.dll` from a `%LOCALAPPDATA%\\Temp\\onefile_*` directory, that is usually a heuristic flag on self-extracting onefile packaging rather than proof of a malicious payload.
+- Preferred mitigation: use the packaged **standalone zip** release and run `PatchOpsIII.exe` from the extracted application folder, not from a temp directory.
+- Additional mitigations:
+  - Keep the app in a stable path such as `C:\\Apps\\PatchOpsIII`.
+  - Restore the file from quarantine and whitelist the PatchOpsIII folder after verifying the download came from GitHub Releases.
+  - Compare the published SHA-256 hash with your local file before creating an antivirus exception.
+  - If packaging-related detections persist, use the developer workflow (`python main.py`) instead of the packaged Windows binary.


### PR DESCRIPTION
### Motivation
- Reduce antivirus/Bitdefender false positives caused by Nuitka onefile extraction to `%LOCALAPPDATA%\Temp\onefile_*` which can lead to `main.dll` being quarantined. 
- Provide a safer packaging workflow and clear end-user guidance so users can run the app without heuristic quarantines. 

### Description
- Switch the Windows CI packaging from a Nuitka `--onefile` build to a `--standalone` build and produce a packaged ZIP artifact instead of a self-extracting onefile executable by updating `.github/workflows/windows-build.yml`. 
- Package the standalone output into `PatchOpsIII-windows.zip`, compute SHA-256 on the zip, run the optional VirusTotal scan against the zip, and upload the zip as the Windows artifact. 
- Update README and `wiki/home.md` to document Bitdefender/antivirus false-positive behavior, recommended mitigations (download from Releases, extract to a stable folder such as `C:\Apps\PatchOpsIII`, restore & whitelist, verify SHA-256), and the fallback to running from source (`python main.py`). 

### Testing
- Ran `python -m compileall main.py updater.py utils.py t7_patch.py dxvk_manager.py bo3_enhanced.py config.py` and the compilation step completed successfully. 
- Ran a validation script that reads the modified files (`.github/workflows/windows-build.yml`, `README.md`, `wiki/home.md`) to ensure they are non-empty and it passed. 
- Performed local smoke checks (`git status`) to verify changes are present; CI workflow updates will be exercised when the repository build runs in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba3407658883299cf2e2172da526f2)