### PR TITLE
chore: update T7Patch to Scroptss v3.02

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ PatchOpsIII streamlines the setup and upkeep of Black Ops III by surfacing popul
 This project would not be possible without the incredible work of the broader community:
 
 - **t7patch** – Security and stability backbone for Black Ops III multiplayer.  
-  [https://github.com/shiversoftdev/t7patch](https://github.com/shiversoftdev/t7patch)
+  Original work by `shiversoftdev`, continued by `Scroptss`: [https://github.com/Scroptss/T7Patch](https://github.com/Scroptss/T7Patch)
 - **dxvk-gplasync** – Vulkan translation layer with async shader compilation.  
   [https://gitlab.com/Ph42oN/dxvk-gplasync](https://gitlab.com/Ph42oN/dxvk-gplasync)
 - **ValvePython/vdf** – Reliable Steam VDF parsing utilities used throughout PatchOpsIII.  

--- a/Release Notes/template.md
+++ b/Release Notes/template.md
@@ -58,7 +58,7 @@
 
 ## 🧑‍💻 Acknowledgements
 PatchOpsIII is built upon the work of these amazing projects:
-- **t7patch:** [t7patch on GitHub](https://github.com/shiversoftdev/t7patch)
+- **t7patch:** [t7patch on GitHub](https://github.com/Scroptss/T7Patch)
 - **dxvk-gplasync:** [dxvk-gplasync on GitLab](https://gitlab.com/Ph42oN/dxvk-gplasync)
 - **ValvePython/vdf:** [ValvePython/vdf on GitHub](https://github.com/ValvePython/vdf)
 

--- a/t7_patch.py
+++ b/t7_patch.py
@@ -26,20 +26,48 @@ T7_INSTALL_MARKERS = (
     "t7patchloader.dll",
     "t7patch.dll",
 )
-T7PATCH_RELEASE_TAG_API = "https://api.github.com/repos/shiversoftdev/t7patch/releases/tags/Current"
+T7PATCH_CORE_REPOSITORY = "Scroptss/T7Patch"
+T7PATCH_CORE_TAG = "v3.02"
+T7PATCH_LEGACY_REPOSITORY = "shiversoftdev/t7patch"
+T7PATCH_LEGACY_TAG = "Current"
 
-# Trusted hashes for the pinned T7Patch "Current" assets.
-# If upstream starts publishing digests in release metadata, those are preferred automatically.
-TRUSTED_T7PATCH_ASSET_SHA256 = {
+
+def _github_release_tag_api(repo_name: str, tag_name: str) -> str:
+    return f"https://api.github.com/repos/{repo_name}/releases/tags/{tag_name}"
+
+
+def _github_release_asset_url(repo_name: str, tag_name: str, asset_name: str) -> str:
+    return f"https://github.com/{repo_name}/releases/download/{tag_name}/{asset_name}"
+
+
+# The maintained Feb 2026-compatible patch now lives in Scroptss/T7Patch. LPC is
+# still sourced from the legacy release because the new fork does not publish it.
+T7PATCH_ASSETS = {
     "Linux.Steamdeck.and.Manual.Windows.Install.zip": {
-        "388491c01643b0abd51f13290d0c36dec9737fcfbb0ed5e2f5ef6804e1b73dcb",
+        "download_url": _github_release_asset_url(
+            T7PATCH_CORE_REPOSITORY,
+            T7PATCH_CORE_TAG,
+            "Linux.Steamdeck.and.Manual.Windows.Install.zip",
+        ),
+        "release_api": _github_release_tag_api(T7PATCH_CORE_REPOSITORY, T7PATCH_CORE_TAG),
+        "trusted_sha256": {
+            "e34411e70d3c99773445ab758851304d7f6a80867a987ec7f4a1a1df72b11bb1",
+        },
     },
     "LPC.1.zip": {
-        "c94855841a233c9dcdea2799c12693fed8554d0e59fe68257ae66ffbdf2fa58b",
+        "download_url": _github_release_asset_url(
+            T7PATCH_LEGACY_REPOSITORY,
+            T7PATCH_LEGACY_TAG,
+            "LPC.1.zip",
+        ),
+        "release_api": _github_release_tag_api(T7PATCH_LEGACY_REPOSITORY, T7PATCH_LEGACY_TAG),
+        "trusted_sha256": {
+            "c94855841a233c9dcdea2799c12693fed8554d0e59fe68257ae66ffbdf2fa58b",
+        },
     },
 }
 
-_t7patch_release_digests_cache = None
+_t7patch_release_digests_cache = {}
 
 def _load_icon(name: str) -> QIcon:
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "icons", f"{name}.svg")
@@ -209,14 +237,13 @@ def restore_lpc_backups(game_dir, log_widget):
         write_log(f"Error restoring LPC backups: {e}", "Error", log_widget)
 
 
-def _fetch_t7patch_release_digests():
-    global _t7patch_release_digests_cache
-    if _t7patch_release_digests_cache is not None:
-        return _t7patch_release_digests_cache
-
+def _fetch_t7patch_release_digests(release_api):
+    cached = _t7patch_release_digests_cache.get(release_api)
+    if cached is not None:
+        return cached
     digests = {}
     try:
-        response = requests.get(T7PATCH_RELEASE_TAG_API, timeout=30)
+        response = requests.get(release_api, timeout=30)
         response.raise_for_status()
         data = response.json()
         for asset in data.get("assets") or []:
@@ -231,16 +258,20 @@ def _fetch_t7patch_release_digests():
         # Network/API failures should not break installs if a trusted pinned hash exists.
         digests = {}
 
-    _t7patch_release_digests_cache = digests
+    _t7patch_release_digests_cache[release_api] = digests
     return digests
 
 
 def _expected_asset_sha256(asset_name, log_widget):
-    api_digest = _fetch_t7patch_release_digests().get(asset_name)
+    asset_meta = T7PATCH_ASSETS.get(asset_name)
+    if not asset_meta:
+        return set()
+
+    api_digest = _fetch_t7patch_release_digests(asset_meta["release_api"]).get(asset_name)
     if api_digest:
         return {api_digest.lower()}
 
-    trusted = {value.lower() for value in TRUSTED_T7PATCH_ASSET_SHA256.get(asset_name, set()) if value}
+    trusted = {value.lower() for value in asset_meta.get("trusted_sha256", set()) if value}
     if trusted:
         write_log(
             f"Release metadata digest unavailable for {asset_name}; using pinned trusted hash.",
@@ -276,7 +307,7 @@ def download_file(url, filename, log_widget, expected_sha256=None):
 
 def install_lpc_files(game_dir, mod_files_dir, log_widget):
     """Download and install LPC files"""
-    zip_url = "https://github.com/shiversoftdev/t7patch/releases/download/Current/LPC.1.zip"
+    zip_url = T7PATCH_ASSETS["LPC.1.zip"]["download_url"]
     zip_dest = os.path.join(mod_files_dir, "LPC.zip")
     temp_dir = os.path.join(mod_files_dir, "LPC_temp")
     lpc_dir = os.path.join(game_dir, "LPC")
@@ -513,8 +544,8 @@ class InstallT7PatchWorker(QThread):
             else:
                 write_log("Linux detected. Skipping antivirus exclusion. Please add an exclusion in your antivirus settings if needed.", "Warning", log_forwarder)
 
-            write_log("Downloading T7 Patch...", "Info", log_forwarder)
-            zip_url = "https://github.com/shiversoftdev/t7patch/releases/download/Current/Linux.Steamdeck.and.Manual.Windows.Install.zip"
+            write_log(f"Downloading T7 Patch {T7PATCH_CORE_TAG}...", "Info", log_forwarder)
+            zip_url = T7PATCH_ASSETS["Linux.Steamdeck.and.Manual.Windows.Install.zip"]["download_url"]
             zip_dest = os.path.join(self.mod_files_dir, "T7Patch.zip")
             source_dir = os.path.join(self.mod_files_dir, "linux")
 

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -37,7 +37,7 @@ PatchOpsIII enables users to:
 
 This management only needs to run once and does not require `t7patch.exe` to remain open in the background. Implementing the T7 Patch is crucial for maintaining game security and performance, as it safeguards against known exploits and enhances overall stability.  
 
-You can learn more about the T7 Patch [here](https://github.com/shiversoftdev/t7patch).  
+You can learn more about the maintained T7 Patch [here](https://github.com/Scroptss/T7Patch).  
 
 #### 1.3 DXVK-GPLAsync Management  
 **Shader compilation stuttering** is a common issue in PC gaming, causing noticeable delays when new shaders are compiled during gameplay. DXVK-GPLAsync offers a solution by converting **DirectX** calls to **Vulkan** with asynchronous shader compilation, reducing stutters for consistently smooth frametimes.


### PR DESCRIPTION
## Summary
- pin the primary T7Patch installer to `Scroptss/T7Patch` `v3.02`
- keep LPC downloads on the legacy `shiversoftdev/t7patch` release because the maintained fork does not publish that asset
- refresh project documentation and the release-notes template to point at the maintained T7Patch repo

## Validation
- `python3 -m py_compile t7_patch.py main.py utils.py`

## Notes
- Part of #31

## Tribute
In memory of `shiversoftdev`: thank you for your work, you can rest now. `Scroptss` will take it from here.
