### PR TITLE
fix(t7patch): use maintained core patch source

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -54,6 +54,7 @@ from bo3_enhanced import (
     validate_dump_source,
 )
 from t7_patch import (
+    T7PATCH_ASSETS,
     _expected_asset_sha256,
     add_defender_exclusion,
     backup_lpc_files,
@@ -747,7 +748,7 @@ def _install_t7_patch(game_dir: str) -> None:
         add_defender_exclusion(game_dir, log_target)
 
     write_log("Downloading T7 Patch...", "Info", log_target)
-    zip_url = "https://github.com/shiversoftdev/t7patch/releases/download/Current/Linux.Steamdeck.and.Manual.Windows.Install.zip"
+    zip_url = T7PATCH_ASSETS["Linux.Steamdeck.and.Manual.Windows.Install.zip"]["download_url"]
     zip_dest = MOD_FILES_DIR / "T7Patch.zip"
     source_dir = MOD_FILES_DIR / "linux"
 


### PR DESCRIPTION
## Summary

Fixes the T7 Patch install flow so the core patch archive is downloaded from the maintained Scroptss/T7Patch asset already defined in `t7_patch.py`.

## Changes

- Import `T7PATCH_ASSETS` into the backend API.
- Use the configured core patch asset URL for `Linux.Steamdeck.and.Manual.Windows.Install.zip` instead of the legacy hardcoded URL.
- Keep LPC install behavior unchanged, so LPC files still come from the legacy release that publishes `LPC.1.zip`.

## Testing

- `python -m py_compile backend\api.py t7_patch.py`
- `git diff --check`

## Notes

Root cause: `_install_t7_patch()` used a legacy hardcoded core archive URL while integrity metadata was resolved from the maintained core asset definition, so the download source and trusted hash source could diverge.